### PR TITLE
Add WrapWith function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `WrapWith` function to wrap an error with message, stack trace and context at the same time
+
 
 ## [0.11.0] - 2018-08-30
 

--- a/context.go
+++ b/context.go
@@ -1,5 +1,10 @@
 package emperror
 
+import (
+	"fmt"
+	"io"
+)
+
 // The implementation bellow is heavily influenced by go-kit's log context.
 
 // With returns a new error with keyvals context appended to it.
@@ -75,4 +80,22 @@ func (e *contextualError) Context() []interface{} {
 // This method fulfills the causer interface described in github.com/pkg/errors.
 func (e *contextualError) Cause() error {
 	return e.error
+}
+
+func (e *contextualError) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", e.Cause())
+			return
+		}
+
+		fallthrough
+
+	case 's':
+		io.WriteString(s, e.Error())
+
+	case 'q':
+		fmt.Fprintf(s, "%q", e.Error())
+	}
 }

--- a/wrap_context.go
+++ b/wrap_context.go
@@ -1,0 +1,32 @@
+package emperror
+
+import "github.com/pkg/errors"
+
+// WrapWith returns an error annotating err with a stack trace
+// at the point Wrap is called (if there is none attached to the error yet), the supplied message,
+// and the supplied context.
+// If err is nil, Wrap returns nil.
+func WrapWith(err error, message string, keyvals ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	_, ok := getStackTracer(err)
+
+	err = errors.WithMessage(err, message)
+
+	// There is no stack trace in the error, so attach it here
+	if !ok {
+		err = &wrappedError{
+			err:   err,
+			stack: callers(),
+		}
+	}
+
+	// Attach context to the error
+	if len(keyvals) > 0 {
+		err = With(err, keyvals...)
+	}
+
+	return err
+}

--- a/wrap_context_test.go
+++ b/wrap_context_test.go
@@ -1,0 +1,86 @@
+package emperror_test
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	. "github.com/goph/emperror"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapWith_Format(t *testing.T) {
+	testError := WrapWith(io.EOF, "error1", "key", "value")
+
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		WrapWith(errors.New("error"), "error2", "key", "value"),
+		"%s",
+		"error2: error",
+	}, {
+		WrapWith(errors.New("error"), "error2", "key", "value"),
+		"%v",
+		"error2: error",
+	}, {
+		WrapWith(errors.New("error"), "error2", "key", "value"),
+		"%+v",
+		"error\n" +
+			"github.com/goph/emperror_test.TestWrapWith_Format\n" +
+			"\t.+/github.com/goph/emperror/wrap_context_test.go:29",
+	}, {
+		WrapWith(io.EOF, "error", "key", "value"),
+		"%s",
+		"error: EOF",
+	}, {
+		WrapWith(io.EOF, "error", "key", "value"),
+		"%v",
+		"error: EOF",
+	}, {
+		WrapWith(io.EOF, "error", "key", "value"),
+		"%+v",
+		"EOF\n" +
+			"error\n" +
+			"github.com/goph/emperror_test.TestWrapWith_Format\n" +
+			"\t.+/github.com/goph/emperror/wrap_context_test.go:43",
+	}, {
+		WrapWith(WrapWith(io.EOF, "error1"), "error2", "key", "value"),
+		"%+v",
+		"EOF\n" +
+			"error1\n" +
+			"github.com/goph/emperror_test.TestWrapWith_Format\n" +
+			"\t.+/github.com/goph/emperror/wrap_context_test.go:50\n",
+	}, {
+		WrapWith(fmt.Errorf("error with space"), "context", "key", "value"),
+		"%q",
+		`"context: error with space"`,
+	}, {
+		WrapWith(testError, "error2", "key", "value"),
+		"%+v",
+		"EOF\n" +
+			"error1\n" +
+			"github.com/goph/emperror_test.TestWrapWith_Format\n" +
+			"\t.+/github.com/goph/emperror/wrap_context_test.go:14\n",
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestWrapWith_Context(t *testing.T) {
+	err := errors.New("error")
+
+	kvs := []interface{}{"a", 123}
+	err = WrapWith(err, "error2", kvs...)
+	kvs[1] = 0 // WrapWith should copy its key values
+
+	ctx := Context(err)
+
+	assert.Equal(t, "a", ctx[0])
+	assert.Equal(t, 123, ctx[1])
+	assert.EqualError(t, err, "error2: error")
+}

--- a/wrap_format_test.go
+++ b/wrap_format_test.go
@@ -1,0 +1,29 @@
+package emperror_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func testFormatRegexp(t *testing.T, n int, arg interface{}, format, want string) {
+	got := fmt.Sprintf(format, arg)
+	gotLines := strings.SplitN(got, "\n", -1)
+	wantLines := strings.SplitN(want, "\n", -1)
+
+	if len(wantLines) > len(gotLines) {
+		t.Errorf("test %d: wantLines(%d) > gotLines(%d):\n got: %q\nwant: %q", n+1, len(wantLines), len(gotLines), got, want)
+		return
+	}
+
+	for i, w := range wantLines {
+		match, err := regexp.MatchString(w, gotLines[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("test %d: line %d: fmt.Sprintf(%q, err):\n got: %q\nwant: %q", n+1, i+1, format, got, want)
+		}
+	}
+}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -3,8 +3,6 @@ package emperror_test
 import (
 	"fmt"
 	"io"
-	"regexp"
-	"strings"
 	"testing"
 
 	. "github.com/goph/emperror"
@@ -31,7 +29,7 @@ func TestWrap_Format(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/goph/emperror_test.TestWrap_Format\n" +
-			"\t.+/github.com/goph/emperror/wrap_test.go:30",
+			"\t.+/github.com/goph/emperror/wrap_test.go:28",
 	}, {
 		Wrap(io.EOF, "error"),
 		"%s",
@@ -46,14 +44,14 @@ func TestWrap_Format(t *testing.T) {
 		"EOF\n" +
 			"error\n" +
 			"github.com/goph/emperror_test.TestWrap_Format\n" +
-			"\t.+/github.com/goph/emperror/wrap_test.go:44",
+			"\t.+/github.com/goph/emperror/wrap_test.go:42",
 	}, {
 		Wrap(Wrap(io.EOF, "error1"), "error2"),
 		"%+v",
 		"EOF\n" +
 			"error1\n" +
 			"github.com/goph/emperror_test.TestWrap_Format\n" +
-			"\t.+/github.com/goph/emperror/wrap_test.go:51\n",
+			"\t.+/github.com/goph/emperror/wrap_test.go:49\n",
 	}, {
 		Wrap(fmt.Errorf("error with space"), "context"),
 		"%q",
@@ -64,31 +62,10 @@ func TestWrap_Format(t *testing.T) {
 		"EOF\n" +
 			"error1\n" +
 			"github.com/goph/emperror_test.TestWrap_Format\n" +
-			"\t.+/github.com/goph/emperror/wrap_test.go:15\n",
+			"\t.+/github.com/goph/emperror/wrap_test.go:13\n",
 	}}
 
 	for i, tt := range tests {
 		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
-	}
-}
-
-func testFormatRegexp(t *testing.T, n int, arg interface{}, format, want string) {
-	got := fmt.Sprintf(format, arg)
-	gotLines := strings.SplitN(got, "\n", -1)
-	wantLines := strings.SplitN(want, "\n", -1)
-
-	if len(wantLines) > len(gotLines) {
-		t.Errorf("test %d: wantLines(%d) > gotLines(%d):\n got: %q\nwant: %q", n+1, len(wantLines), len(gotLines), got, want)
-		return
-	}
-
-	for i, w := range wantLines {
-		match, err := regexp.MatchString(w, gotLines[i])
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !match {
-			t.Errorf("test %d: line %d: fmt.Sprintf(%q, err):\n got: %q\nwant: %q", n+1, i+1, format, got, want)
-		}
 	}
 }


### PR DESCRIPTION
This PR adds a new function which combines the behavior of `Wrap` and `With`.

The API before:

```go
// some code
if err != nil {
	return nil, emperror.With(emperror.Wrap(err, "some error happened"), "key", "value)
}
```

The API after:

```go
// some code
if err != nil {
	return nil, emperror.WrapWith(err, "some error happened", "key", "value)
}
```